### PR TITLE
Add visual comparison notebook

### DIFF
--- a/visual_comparison.ipynb
+++ b/visual_comparison.ipynb
@@ -1,0 +1,441 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visual comparisons\n",
+    "\n",
+    "This notebook is a simple visualization of the differences between two networks by combining tools available in this repository.\n",
+    "\n",
+    "To execute this notebook, you can use the pypsa-earth environment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Initial setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "General imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google_drive_downloader import GoogleDriveDownloader as gdd\n",
+    "from pathlib import Path\n",
+    "import pypsa\n",
+    "import pandas as pd\n",
+    "import geopandas as gpd\n",
+    "from pypsa.clustering.spatial import get_clustering_from_busmap\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Specify what networks to compare"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use_drive enables to download default data from gdrive\n",
+    "# When use_drive is true and the path of the file is not found,\n",
+    "# but it matches a value from dictionary file_ids,\n",
+    "# then the file is downloaded from gdrive\n",
+    "use_gdrive = True  \n",
+    "\n",
+    "path_network_1 = \"data/pypsa-eur/networks/elec_s_512.nc\"\n",
+    "path_network_2 = \"data/pypsa-earth/networks/elec_s_110.nc\"\n",
+    "gadm_shape = \"data/pypsa-earth/resources/shapes/gadm_shapes.geojson\"\n",
+    "country_shape = \"data/pypsa-earth/resources/shapes/country_shapes.geojson\"\n",
+    "\n",
+    "comparison_methodology = {\n",
+    "    \"method\": \"shape\",\n",
+    "    \"options\": {\n",
+    "        \"path\": \"data/pypsa-earth/resources/shapes/country_shapes.geojson\"\n",
+    "    }\n",
+    "}  # method option among: [\"country_shape\", \"gadm_shape\", ...]\n",
+    "# TODO: expand to include network_1 and network_2; example: create voronoi polygons and compare them or alike,\n",
+    "# or \"find_closest\" to compare the closest nodes\n",
+    "\n",
+    "# file_ids of default gdrive data\n",
+    "file_ids = {\n",
+    "    # PyPSA-Eur\n",
+    "    \"data/pypsa-eur/networks/elec_s_1024.nc\": \"1GQxNVwpU62YVlWiupFUVMG0Ipu_3UUUd\",  # 200Mb!!!\n",
+    "    \"data/pypsa-eur/networks/elec_s_512.nc\": \"1HiOyMzZGA75LfNhFnGU_ntnmjO9CPfEo\",\n",
+    "    \"data/pypsa-eur/networks/elec_s_256.nc\": \"1JphEeBz3vdVKY0uKnnHSf-f4k9223emg\",\n",
+    "    \"data/pypsa-eur/networks/elec.nc\": \"16DHvFbNah9LblbXOjIbZ6H0cHmCaYH_U\",  # % 500Mb!!\n",
+    "    \"data/pypsa-eur/networks/base.nc\": \"1JphEeBz3vdVKY0uKnnHSf-f4k9223emg\",\n",
+    "    # PyPSA-Earth\n",
+    "    \"data/pypsa-earth/networks/elec_s_110.nc\": \"12muoaSDkROjTD5cAw143jh3FBPXufNf5\",\n",
+    "    \"data/pypsa-earth/networks/elec.nc\": \"1jEtsC8ma9YnAegMxOV4tQWbE4msIoGqT\",  # 2Gb!!!\n",
+    "    \"data/pypsa-earth/networks/base.nc\": \"157l0eo8UbmF1HSXaRVb_0ErWXvhPhNka\",\n",
+    "    \"data/pypsa-earth/resources/shapes/gadm_shapes.geojson\": \"1DsAn53rTK7Wz6rnga2ogXEnGpXiH5yN4\",\n",
+    "    \"data/pypsa-earth/resources/shapes/country_shapes.geojson\": \"1-KxaGSdSXyOlqSfkYNvvJMjZavXQ4Sih\",\n",
+    "}\n",
+    "\n",
+    "# global crs parameters\n",
+    "GEO_CRS = \"EPSG:4326\"\n",
+    "METRIC_CRS = \"EPSG:3857\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Initial downloads from gdrive for template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# utility function for gdrive\n",
+    "def download_grive(file_id, dest_path, showsize=False):\n",
+    "    gdd.download_file_from_google_drive(\n",
+    "        file_id=file_id,\n",
+    "        dest_path=dest_path,\n",
+    "        showsize=showsize,\n",
+    "        unzip=False,\n",
+    "    )\n",
+    "\n",
+    "files_to_download = [path_network_1, path_network_2, gadm_shape, country_shape]\n",
+    "\n",
+    "for fpath in files_to_download:\n",
+    "    pl_path = Path(fpath)\n",
+    "\n",
+    "    # skip if file exists\n",
+    "    if pl_path.is_file():\n",
+    "        print(f\"File '{fpath}' found\")\n",
+    "        continue\n",
+    "\n",
+    "    if use_gdrive:\n",
+    "        if fpath in file_ids:\n",
+    "            pl_path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "            download_grive(file_ids[fpath], fpath)\n",
+    "        else:\n",
+    "            print(f\"File '{fpath}' not found and not in file_ids\")\n",
+    "            raise FileNotFoundError(fpath)\n",
+    "    else:\n",
+    "        print(f\"File '{fpath}' found\")\n",
+    "        raise FileNotFoundError(fpath)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Comparison methodology"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load networks\n",
+    "n1 = pypsa.Network(path_network_1)  # first network\n",
+    "n2 = pypsa.Network(path_network_2)  # second network\n",
+    "\n",
+    "# Utility function for dataframe to geodataframe conversion\n",
+    "def buses_to_geodf(df_buses, INPUT_CRS=GEO_CRS, OUTPUT_CRS=METRIC_CRS):\n",
+    "    \"\"\"Function to transform a buses dataframe into a geodataframe with the correct crs.\"\"\"\n",
+    "    return gpd.GeoDataFrame(\n",
+    "        df_buses,\n",
+    "        geometry=gpd.points_from_xy(df_buses.x, df_buses.y),\n",
+    "        crs=INPUT_CRS,\n",
+    "    ).to_crs(OUTPUT_CRS)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create mapping of the networks for comparison purposes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Utility functions for mapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def shape_mapping(n, options):\n",
+    "    \"\"\"Create mapping by shape\"\"\"\n",
+    "    gdf = gpd.read_file(options[\"path\"])\n",
+    "\n",
+    "    # create GADM_ID and country if missing (country_shapes.geojson)\n",
+    "    if \"GADM_ID\" not in gdf.columns:\n",
+    "        gdf[\"GADM_ID\"] = gdf[\"name\"]\n",
+    "    if \"country\" not in gdf.columns:\n",
+    "        gdf[\"country\"] = gdf[\"name\"]\n",
+    "    \n",
+    "    gdf.set_index(\"GADM_ID\", inplace=True)\n",
+    "    df_mapped = n.buses.groupby(\"country\").apply(\n",
+    "        lambda x: gpd.sjoin_nearest(buses_to_geodf(x), gdf[gdf.country==x.name].to_crs(METRIC_CRS), how=\"inner\")\n",
+    "    ).droplevel(0, axis=0)\n",
+    "    return (df_mapped[\"index_right\"] + \" \" + df_mapped.carrier).rename(\"mapping\")\n",
+    "\n",
+    "\n",
+    "def create_bus_mapping(n, method):\n",
+    "    \"\"\"Function to create the bus mapping of network n according to a given methodology\"\"\"\n",
+    "    match method[\"method\"]:\n",
+    "        case \"shape\":\n",
+    "            return shape_mapping(n, method[\"options\"])\n",
+    "        case _:\n",
+    "            raise NotImplementedError(f\"Method {method['method']} not implemented\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aggregation_strategies = {\n",
+    "    \"generators\": {  # use \"min\" for more conservative assumptions\n",
+    "        \"p_nom\": \"sum\",\n",
+    "        \"p_nom_max\": \"sum\",\n",
+    "        \"p_nom_min\": \"sum\",\n",
+    "        \"p_min_pu\": \"mean\",\n",
+    "        \"marginal_cost\": \"mean\",\n",
+    "        \"committable\": \"any\",\n",
+    "        \"ramp_limit_up\": \"max\",\n",
+    "        \"ramp_limit_down\": \"max\",\n",
+    "        \"efficiency\": \"mean\",\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "def get_aggregation_strategies(aggregation_strategies):\n",
+    "    \"\"\"\n",
+    "    Default aggregation strategies that cannot be defined in .yaml format must\n",
+    "    be specified within the function, otherwise (when defaults are passed in\n",
+    "    the function's definition) they get lost when custom values are specified\n",
+    "    in the config.\n",
+    "    \"\"\"\n",
+    "    import numpy as np\n",
+    "\n",
+    "    # to handle the new version of PyPSA.\n",
+    "    try:\n",
+    "        from pypsa.clustering.spatial import _make_consense\n",
+    "    except Exception:\n",
+    "        # TODO: remove after new release and update minimum pypsa version\n",
+    "        from pypsa.clustering.spatial import _make_consense\n",
+    "\n",
+    "    bus_strategies = dict(country=_make_consense(\"Bus\", \"country\"))\n",
+    "    bus_strategies.update(aggregation_strategies.get(\"buses\", {}))\n",
+    "\n",
+    "    generator_strategies = {\"build_year\": lambda x: 0, \"lifetime\": lambda x: np.inf}\n",
+    "    generator_strategies.update(aggregation_strategies.get(\"generators\", {}))\n",
+    "\n",
+    "    return bus_strategies, generator_strategies\n",
+    "\n",
+    "# Bus aggregation strategies\n",
+    "\n",
+    "def create_clustering(n, busmap, aggregation_strategies=aggregation_strategies):\n",
+    "    # get aggregation strategies\n",
+    "    bus_strategies, generator_strategies = get_aggregation_strategies(aggregation_strategies)\n",
+    "\n",
+    "    # get clustering\n",
+    "    clustering = get_clustering_from_busmap(\n",
+    "        n,\n",
+    "        busmap,\n",
+    "        bus_strategies=bus_strategies,\n",
+    "        aggregate_generators_weighted=True,\n",
+    "        aggregate_generators_carriers=None,\n",
+    "        aggregate_one_ports=[\"Load\", \"StorageUnit\"],\n",
+    "        line_length_factor=1.0,\n",
+    "        generator_strategies=generator_strategies,\n",
+    "        scale_link_capital_costs=False,\n",
+    "    )\n",
+    "    return clustering.network, busmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_clustered_network(n, method):\n",
+    "    return create_clustering(n, create_bus_mapping(n, method))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Execute the mapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n1_mapped, n1_mapped_busmap = create_clustered_network(n1, comparison_methodology)\n",
+    "n2_mapped, n2_mapped_busmap = create_clustered_network(n2, comparison_methodology)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Execute the comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### General statistics by networks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s1 = n1_mapped.statistics()\n",
+    "s1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s2 = n2_mapped.statistics()\n",
+    "s2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculate percentage difference [\\%]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delta_mapped = s2 - s1\n",
+    "delta_mapped_pc = delta_mapped / s1 * 100\n",
+    "delta_mapped_pc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n2.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Compare lines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# utility function\n",
+    "def add_line_names(lines):\n",
+    "    \"\"\"Prepare line names for comparison\"\"\"\n",
+    "    lines[\"carrier\"] = lines.bus0.str.split().str[1]\n",
+    "    lines[\"name\"] = lines.bus0.str.split().str[0] + \" - \" + lines.bus1.str.split().str[0]\n",
+    "\n",
+    "    return lines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compare lines as dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lines1 = add_line_names(n1_mapped.lines.copy()).set_index(\"name\")\n",
+    "lines2 = add_line_names(n2_mapped.lines.copy()).set_index(\"name\")\n",
+    "\n",
+    "carrier = pd.concat([lines1.carrier, lines2.carrier[lines2.index.difference(lines1.index)]], ignore_index=False)\n",
+    "\n",
+    "delta_lines = pd.concat([carrier, lines1.s_nom.rename(\"lines 1\"), lines2.s_nom.rename(\"lines 2\")], axis=1).fillna(0)\n",
+    "delta_lines[\"bus0\"] = delta_lines.index.str.split(\" - \").str[0] \n",
+    "delta_lines[\"bus1\"] = delta_lines.index.str.split(\" - \").str[1] \n",
+    "delta_lines[\"delta\"] = delta_lines[\"lines 2\"] - delta_lines[\"lines 1\"]\n",
+    "delta_lines[\"delta_pu\"] = (delta_lines[\"delta\"] / (delta_lines[\"lines 1\"] + delta_lines[\"lines 2\"]) * 2).fillna(0)\n",
+    "delta_lines[\"delta_pc\"] = delta_lines[\"delta_pu\"] * 100\n",
+    "\n",
+    "header_cols = [\"carrier\", \"bus0\", \"bus1\", \"lines 1\", \"lines 2\", \"delta\", \"delta_pu\", \"delta_pc\"]\n",
+    "delta_lines = delta_lines[header_cols]\n",
+    "delta_lines"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pypsa-earth",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a notebook that includes:

- a draft implementation of automatic download of sample networks from gdrive
- a draft comparison of two networks, that are clustered according to a given shape file (the country_shapes and gadm_shapes are supported)
- a simple comparison procedure of general statistics, buses and lines